### PR TITLE
Refactor `randomElement` utility function

### DIFF
--- a/src/modules/languageStatus.module.ts
+++ b/src/modules/languageStatus.module.ts
@@ -4,6 +4,7 @@ import { logger } from "../logging.js";
 import { awaitTimeout } from "../util/timeouts.js";
 import { hotTakeData, hotTakeValue } from "./hotTakes/hotTakes.util.js";
 import { ActivityType } from "discord.js";
+import randomElementFromArray from "../util/random.js";
 
 export const LanguageStatusModule: Module = {
   name: "languageStatus",
@@ -11,7 +12,11 @@ export const LanguageStatusModule: Module = {
     {
       async ready(client, event) {
         while (client.isReady()) {
-          const lang = hotTakeData.languages.randomElement();
+          const lang = randomElementFromArray(hotTakeData.languages);
+          if (lang == null) {
+            logger.error("No languages found in hot take data");
+            continue;
+          }
           event.user.setActivity(`Coding in ${hotTakeValue(lang)}`, {
             type: ActivityType.Playing,
           });

--- a/src/util/random.ts
+++ b/src/util/random.ts
@@ -1,14 +1,9 @@
-// Used to add randomElement, eslint is dumb
-
-declare global {
-  interface Array<T> {
-    randomElement: () => T;
+export default function randomElementFromArray<T>(array: T[]): T | undefined {
+  if (array.length === 0) {
+    return undefined;
   }
+  if (array.length === 1) {
+    return array[0]!;
+  }
+  return array[Math.floor(Math.random() * array.length)]!;
 }
-
-Array.prototype.randomElement = function randomElement<T>(this: T[]): T {
-  if (this.length === 1) {
-    return this[0]!;
-  }
-  return this[Math.floor(Math.random() * this.length)]!;
-};


### PR DESCRIPTION
Instead manipulating the prototype its cleaner to not touch the prototype. ( Especially for nothing required or manipulating the default behaviour  )